### PR TITLE
Positional args for db connect function are passed in the right order

### DIFF
--- a/public_html/classes/PersistenceStore.php
+++ b/public_html/classes/PersistenceStore.php
@@ -10,9 +10,9 @@ class PersistenceStore
   {
     $this->conn = getDatabaseConnection(
       $_ENV["MYSQL_HOSTNAME"],
-      $_ENV["MYSQL_DATABASE"],
       $_ENV["MYSQL_USERNAME"],
-      $_ENV["MYSQL_PASSWORD"]
+      $_ENV["MYSQL_PASSWORD"],
+      $_ENV["MYSQL_DATABASE"]
     );
   }
 


### PR DESCRIPTION
This bug cost me ~ 1hr of time :/
Note to self: Use different mock values for db, hostname, username, password